### PR TITLE
添加 `singleton` 函数以防止 LOLauncher 应用程序的多实例运行

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,5 @@
 from ui.app import App
-from utils import read_json, check_for_updates, verify_metadata_file, CONFIG_FILENAME, GUI_CONFIG_FILENAME
+from utils import read_json, check_for_updates, verify_metadata_file, singleton, CONFIG_FILENAME, GUI_CONFIG_FILENAME
 
 if __name__ == '__main__':
     # if not is_admin():
@@ -7,6 +7,7 @@ if __name__ == '__main__':
     #     sys.exit()
     # Don't need to run as administrator since v1.0.2
 
+    singleton()
     check_for_updates()
 
     config = read_json(CONFIG_FILENAME) or {}

--- a/src/main.py
+++ b/src/main.py
@@ -18,7 +18,7 @@ if __name__ == '__main__':
 
 
     def on_message(message):
-        if message == "SHOW_YOURSELF":
+        if message == 'SHOW_YOURSELF':
             app.show_window()
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,8 @@
+import sys
+import threading
 from ui.app import App
-from utils import read_json, check_for_updates, verify_metadata_file, singleton, CONFIG_FILENAME, GUI_CONFIG_FILENAME
+from utils import read_json, check_for_updates, verify_metadata_file, singleton, show_existing_instance, start_server, \
+    CONFIG_FILENAME, GUI_CONFIG_FILENAME
 
 if __name__ == '__main__':
     # if not is_admin():
@@ -7,8 +10,20 @@ if __name__ == '__main__':
     #     sys.exit()
     # Don't need to run as administrator since v1.0.2
 
-    singleton()
+    main_instance = singleton()
+    if not main_instance:
+        show_existing_instance()
+        sys.exit(0)
     check_for_updates()
+
+
+    def on_message(message):
+        if message == "SHOW_YOURSELF":
+            app.show_window()
+
+
+    server_thread = threading.Thread(target=start_server, args=(on_message,), daemon=True)
+    server_thread.start()
 
     config = read_json(CONFIG_FILENAME) or {}
     ui_config = read_json(GUI_CONFIG_FILENAME) or {}

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -408,7 +408,7 @@ class App:
 
 
     def show_window(self):
-        print("Showing window")
+        print('Showing window')
 
         if not self.root.winfo_viewable():
             self.root.deiconify()

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -405,3 +405,16 @@ class App:
                 icon.stop()
             self.sync_config()
             self.root.after(0, self.root.destroy)
+
+
+    def show_window(self):
+        print("Showing window")
+
+        if not self.root.winfo_viewable():
+            self.root.deiconify()
+
+        self.root.lift()
+        self.root.focus_force()
+
+        self.root.attributes('-topmost', True)
+        self.root.attributes('-topmost', False)

--- a/src/utils.py
+++ b/src/utils.py
@@ -426,8 +426,8 @@ def send_text(text):
 def show_existing_instance():
     try:
         with socket.create_connection((HOST, PORT), timeout=1) as conn:
-            conn.sendall(b"SHOW_YOURSELF\n")
-            print("Another instance is running, message sent.")
+            conn.sendall(b'SHOW_YOURSELF\n')
+            print('Another instance is running, message sent.')
         return True
     except Exception:
         return False
@@ -455,7 +455,7 @@ def start_server(on_message_callback):
     thread = threading.Thread(target=listen_loop, daemon=True)
     thread.start()
 
-def singleton(mutex_name="LOLauncher"):
+def singleton(mutex_name='LOLauncher'):
     mutex = ctypes.windll.kernel32.CreateMutexW(None, False, mutex_name)
     if ctypes.windll.kernel32.GetLastError() == 183:
         return False

--- a/src/utils.py
+++ b/src/utils.py
@@ -416,3 +416,11 @@ def send_text(text):
     time.sleep(0.05)
     keyboard.write(text)
     keyboard.send('enter')
+
+
+def singleton(mutex_name="LOLauncher"):
+    """Ensure only one instance of the application is running."""
+    mutex = ctypes.windll.kernel32.CreateMutexW(None, False, mutex_name)
+    if ctypes.windll.kernel32.GetLastError() == 183:
+        sys.exit()
+


### PR DESCRIPTION
## 这个 PR 做了什么？
本次 PR 引入了一个 `singleton` 函数，以确保应用程序在运行时仅有一个实例。这可以防止意外启动多个实例，从而避免潜在的冲突或错误。如果已有实例在后台或系统托盘中运行，则自动唤起该已运行实例的主窗口并置于前台。

## 修改内容：
- 在 `utils.py` 中新增 IPC 逻辑
   - 通过在本地 `127.0.0.1` 上创建一个监听端口实现IPC，以便接收“SHOW_WINDOW”命令。  

- 在 `main.py` 中整合单实例与 IPC
   - 启动时先调用 `src.utils.singleton()` 检测是否已有实例正在运行。  
   - 若已存在，则向该实例的 IPC 服务器发送“SHOW_YOURSELF”命令，并立即退出当前进程。  
   - 若不存在，则继续初始化 IPC 服务器，并运行主应用。

- 在 `ui/app.py` 中实现 `show_window` 方法
